### PR TITLE
Logging

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -33,14 +33,14 @@ files = [
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.0"
+version = "1.1.1"
 description = "Backport of PEP 654 (exception groups)"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.1.0-py3-none-any.whl", hash = "sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e"},
-    {file = "exceptiongroup-1.1.0.tar.gz", hash = "sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23"},
+    {file = "exceptiongroup-1.1.1-py3-none-any.whl", hash = "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e"},
+    {file = "exceptiongroup-1.1.1.tar.gz", hash = "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"},
 ]
 
 [package.extras]
@@ -242,25 +242,25 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "protobuf"
-version = "4.22.0"
+version = "4.22.1"
 description = ""
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "protobuf-4.22.0-cp310-abi3-win32.whl", hash = "sha256:b2fea9dc8e3c0f32c38124790ef16cba2ee0628fe2022a52e435e1117bfef9b1"},
-    {file = "protobuf-4.22.0-cp310-abi3-win_amd64.whl", hash = "sha256:a33a273d21852f911b8bda47f39f4383fe7c061eb1814db2c76c9875c89c2491"},
-    {file = "protobuf-4.22.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:e894e9ae603e963f0842498c4cd5d39c6a60f0d7e4c103df50ee939564298658"},
-    {file = "protobuf-4.22.0-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:7c535d126e7dcc714105ab20b418c4fedbd28f8b8afc42b7350b1e317bbbcc71"},
-    {file = "protobuf-4.22.0-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:86c3d20428b007537ba6792b475c0853bba7f66b1f60e610d913b77d94b486e4"},
-    {file = "protobuf-4.22.0-cp37-cp37m-win32.whl", hash = "sha256:1669cb7524221a8e2d9008d0842453dbefdd0fcdd64d67672f657244867635fb"},
-    {file = "protobuf-4.22.0-cp37-cp37m-win_amd64.whl", hash = "sha256:ab4d043865dd04e6b09386981fe8f80b39a1e46139fb4a3c206229d6b9f36ff6"},
-    {file = "protobuf-4.22.0-cp38-cp38-win32.whl", hash = "sha256:29288813aacaa302afa2381db1d6e0482165737b0afdf2811df5fa99185c457b"},
-    {file = "protobuf-4.22.0-cp38-cp38-win_amd64.whl", hash = "sha256:e474b63bab0a2ea32a7b26a4d8eec59e33e709321e5e16fb66e766b61b82a95e"},
-    {file = "protobuf-4.22.0-cp39-cp39-win32.whl", hash = "sha256:47d31bdf58222dd296976aa1646c68c6ee80b96d22e0a3c336c9174e253fd35e"},
-    {file = "protobuf-4.22.0-cp39-cp39-win_amd64.whl", hash = "sha256:c27f371f0159feb70e6ea52ed7e768b3f3a4c5676c1900a7e51a24740381650e"},
-    {file = "protobuf-4.22.0-py3-none-any.whl", hash = "sha256:c3325803095fb4c2a48649c321d2fbde59f8fbfcb9bfc7a86df27d112831c571"},
-    {file = "protobuf-4.22.0.tar.gz", hash = "sha256:652d8dfece122a24d98eebfef30e31e455d300efa41999d1182e015984ac5930"},
+    {file = "protobuf-4.22.1-cp310-abi3-win32.whl", hash = "sha256:85aa9acc5a777adc0c21b449dafbc40d9a0b6413ff3a4f77ef9df194be7f975b"},
+    {file = "protobuf-4.22.1-cp310-abi3-win_amd64.whl", hash = "sha256:8bc971d76c03f1dd49f18115b002254f2ddb2d4b143c583bb860b796bb0d399e"},
+    {file = "protobuf-4.22.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:5917412347e1da08ce2939eb5cd60650dfb1a9ab4606a415b9278a1041fb4d19"},
+    {file = "protobuf-4.22.1-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:9e12e2810e7d297dbce3c129ae5e912ffd94240b050d33f9ecf023f35563b14f"},
+    {file = "protobuf-4.22.1-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:953fc7904ef46900262a26374b28c2864610b60cdc8b272f864e22143f8373c4"},
+    {file = "protobuf-4.22.1-cp37-cp37m-win32.whl", hash = "sha256:6e100f7bc787cd0a0ae58dbf0ab8bbf1ee7953f862b89148b6cf5436d5e9eaa1"},
+    {file = "protobuf-4.22.1-cp37-cp37m-win_amd64.whl", hash = "sha256:87a6393fa634f294bf24d1cfe9fdd6bb605cbc247af81b9b10c4c0f12dfce4b3"},
+    {file = "protobuf-4.22.1-cp38-cp38-win32.whl", hash = "sha256:e3fb58076bdb550e75db06ace2a8b3879d4c4f7ec9dd86e4254656118f4a78d7"},
+    {file = "protobuf-4.22.1-cp38-cp38-win_amd64.whl", hash = "sha256:651113695bc2e5678b799ee5d906b5d3613f4ccfa61b12252cfceb6404558af0"},
+    {file = "protobuf-4.22.1-cp39-cp39-win32.whl", hash = "sha256:67b7d19da0fda2733702c2299fd1ef6cb4b3d99f09263eacaf1aa151d9d05f02"},
+    {file = "protobuf-4.22.1-cp39-cp39-win_amd64.whl", hash = "sha256:b8700792f88e59ccecfa246fa48f689d6eee6900eddd486cdae908ff706c482b"},
+    {file = "protobuf-4.22.1-py3-none-any.whl", hash = "sha256:3e19dcf4adbf608924d3486ece469dd4f4f2cf7d2649900f0efcd1a84e8fd3ba"},
+    {file = "protobuf-4.22.1.tar.gz", hash = "sha256:dce7a55d501c31ecf688adb2f6c3f763cf11bc0be815d1946a84d74772ab07a7"},
 ]
 
 [[package]]
@@ -339,20 +339,38 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "67.4.0"
+version = "67.6.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.4.0-py3-none-any.whl", hash = "sha256:f106dee1b506dee5102cc3f3e9e68137bbad6d47b616be7991714b0c62204251"},
-    {file = "setuptools-67.4.0.tar.gz", hash = "sha256:e5fd0a713141a4a105412233c63dc4e17ba0090c8e8334594ac790ec97792330"},
+    {file = "setuptools-67.6.0-py3-none-any.whl", hash = "sha256:b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2"},
+    {file = "setuptools-67.6.0.tar.gz", hash = "sha256:2ee892cd5f29f3373097f5a814697e397cf3ce313616df0af11231e2ad118077"},
 ]
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
 testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
+name = "structlog"
+version = "22.3.0"
+description = "Structured Logging for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "structlog-22.3.0-py3-none-any.whl", hash = "sha256:b403f344f902b220648fa9f286a23c0cc5439a5844d271fec40562dbadbc70ad"},
+    {file = "structlog-22.3.0.tar.gz", hash = "sha256:e7509391f215e4afb88b1b80fa3ea074be57a5a17d794bd436a5c949da023333"},
+]
+
+[package.extras]
+dev = ["structlog[docs,tests,typing]"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "twisted"]
+tests = ["coverage[toml]", "freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "pytest-asyncio (>=0.17)", "simplejson"]
+typing = ["mypy", "rich", "twisted"]
 
 [[package]]
 name = "tomli"
@@ -386,4 +404,4 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.10, < 4"
-content-hash = "ac794bde6c90976414f2d59339ba2301fa16913ee4dc5f363928e22fec26f1b8"
+content-hash = "6fd0e5c41a86f0f3bdb14e48fc3a0680109e3da310fed489a96919374052b8db"

--- a/prefab_cloud_python/_processors.py
+++ b/prefab_cloud_python/_processors.py
@@ -1,0 +1,82 @@
+import prefab_pb2 as Prefab
+import re
+import os
+from structlog import DropEvent
+
+LOG_LEVEL_BASE_KEY = "log-level"
+
+LLV = Prefab.LogLevel.Value
+
+prefab_to_python_log_levels = {
+    LLV("NOT_SET_LOG_LEVEL"): LLV("DEBUG"),
+    LLV("TRACE"): LLV("DEBUG"),
+    LLV("DEBUG"): LLV("DEBUG"),
+    LLV("INFO"): LLV("INFO"),
+    LLV("WARN"): LLV("WARN"),
+    LLV("ERROR"): LLV("ERROR"),
+    LLV("FATAL"): LLV("FATAL"),
+}
+python_to_prefab_log_levels = {
+    "debug": LLV("DEBUG"),
+    "info": LLV("INFO"),
+    "warn": LLV("WARN"),
+    "warning": LLV("WARN"),
+    "error": LLV("ERROR"),
+    "critical": LLV("FATAL"),
+}
+
+
+def clean_event_dict(_, __, event_dict):
+    event_dict.pop("pathname")
+    event_dict.pop("func_name")
+    event_dict.pop("config_client")
+    event_dict.pop("log_prefix")
+    return event_dict
+
+
+def set_location(_, __, event_dict):
+    event_dict["location"] = get_path(event_dict["pathname"], event_dict["func_name"], event_dict["log_prefix"])
+    return event_dict
+
+
+def log_or_drop(_, method, event_dict):
+    location = event_dict["location"]
+    config_client = event_dict["config_client"]
+    closest_log_level = get_severity(location, config_client)
+    called_method_level = python_to_prefab_log_levels[method]
+
+    if closest_log_level > called_method_level:
+        raise DropEvent
+
+    return event_dict
+
+
+def get_severity(location, config_client):
+    default = Prefab.LogLevel.Value("WARN")
+    closest_log_level = config_client.get(LOG_LEVEL_BASE_KEY, default=default)
+
+    path_segs = location.split(".")
+    for i, _ in enumerate(path_segs):
+        next_search_path = ".".join([LOG_LEVEL_BASE_KEY, *path_segs[:i+1]])
+        next_level = config_client.get(next_search_path, default=closest_log_level)
+        if next_level is not None:
+            closest_log_level = next_level
+    return prefab_to_python_log_levels[closest_log_level]
+
+
+def get_path(path, func_name, prefix=None):
+    if "site-packages" in path:
+        path = path.split("site-packages/")[-1]
+    else:
+        path = path.replace(os.environ.get("HOME") + "/", "")
+        path = path.split("/")[-3:]
+        path = ".".join(path)
+
+    path = path.lower()
+    path = re.sub(".pyc?$", "", path)
+    path = re.sub("-", "_", path)
+
+    if isinstance(prefix, str):
+        return "%s.%s.%s" % (prefix, path, func_name)
+    else:
+        return "%s.%s" % (path, func_name)

--- a/prefab_cloud_python/client.py
+++ b/prefab_cloud_python/client.py
@@ -1,8 +1,8 @@
-import logging
 import functools
 from .config_client import ConfigClient
 from .feature_flag_client import FeatureFlagClient
 import prefab_pb2 as Prefab
+from .logger_client import LoggerClient
 
 
 class Client:
@@ -40,7 +40,9 @@ class Client:
 
     @functools.cache
     def config_client(self):
-        return ConfigClient(self, timeout=5.0)
+        client = ConfigClient(self, timeout=5.0)
+        self.logger().set_config_client(client)
+        return client
 
     @functools.cache
     def feature_flag_client(self):
@@ -48,17 +50,4 @@ class Client:
 
     @functools.cache
     def logger(self):
-        log = logging.getLogger("prefab")
-        log.setLevel(logging.DEBUG)
-
-        handler = logging.StreamHandler()
-        handler.setLevel(logging.DEBUG)
-
-        formatter = logging.Formatter(
-            '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-
-        handler.setFormatter(formatter)
-
-        log.addHandler(handler)
-
-        return log
+        return LoggerClient(self.options.log_prefix)

--- a/prefab_cloud_python/config_parser.py
+++ b/prefab_cloud_python/config_parser.py
@@ -1,14 +1,13 @@
 import prefab_pb2 as Prefab
 
+from prefab_cloud_python._processors import LOG_LEVEL_BASE_KEY
+
 
 class MissingFeatureFlagValueException(Exception):
     "Raised when a feature flag is missing a value"
 
     def __init__(self, key, source):
         super().__init__("Feature flag config `%s` in %s must have a `value`" % (key, source))
-
-
-LOG_LEVEL_BASE_KEY = "log-level"
 
 
 class ConfigParser:

--- a/prefab_cloud_python/logger_client.py
+++ b/prefab_cloud_python/logger_client.py
@@ -1,0 +1,64 @@
+import structlog
+import os
+from ._processors import clean_event_dict, set_location, log_or_drop
+
+
+structlog.configure(
+    processors=[
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.StackInfoRenderer(),
+        structlog.dev.set_exc_info,
+        structlog.processors.TimeStamper(),
+        structlog.processors.CallsiteParameterAdder(
+            [
+                structlog.processors.CallsiteParameter.PATHNAME,
+                structlog.processors.CallsiteParameter.FUNC_NAME,
+            ],
+            additional_ignores=["prefab_cloud_python.logger_client"]
+        ),
+        set_location,
+        log_or_drop,
+        clean_event_dict,
+        structlog.dev.ConsoleRenderer(),
+    ]
+)
+
+
+class BootstrappingConfigClient:
+    def get(self, _key, default=None):
+        bootstrap_log_level = os.environ.get("PREFAB_LOG_CLIENT_BOOTSTRAP_LOG_LEVEL")
+        if bootstrap_log_level is not None:
+            return bootstrap_log_level.upper()
+        return default
+
+
+class LoggerClient:
+    def __init__(self, log_prefix=None):
+        self.log_prefix = log_prefix
+        self.config_client = BootstrappingConfigClient()
+
+    def debug(self, msg):
+        self.configured_logger().debug(msg)
+
+    def info(self, msg):
+        self.configured_logger().info(msg)
+
+    def warn(self, msg):
+        self.configured_logger().warn(msg)
+
+    def error(self, msg):
+        self.configured_logger().error(msg)
+
+    def critical(self, msg):
+        self.configured_logger().critical(msg)
+
+    def set_config_client(self, config_client):
+        self.config_client = config_client
+
+    def add_config_client(self, _, __, event_dict):
+        event_dict["config_client"] = self.config_client
+        return event_dict
+
+    def configured_logger(self):
+        return structlog.get_logger().bind(config_client=self.config_client, log_prefix=self.log_prefix)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ pytest = "7.2.1"
 pyyaml = "6.0.0"
 mmh3 = "3.0.0"
 urllib3 = "1.26"
+structlog = "^22.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_logger_client.py
+++ b/tests/test_logger_client.py
@@ -1,0 +1,71 @@
+from prefab_cloud_python._processors import get_path, get_severity
+from prefab_cloud_python import Options, Client
+import prefab_pb2 as Prefab
+import pytest
+import re
+
+
+@pytest.fixture
+def client():
+    options = Options(
+        prefab_config_classpath_dir="tests",
+        prefab_envs=["unit_tests"],
+        prefab_datasources="LOCAL_ONLY"
+    )
+    return Client(options)
+
+
+class TestLoggerClient:
+    def test_get_path(self):
+        assert get_path("/Users/mikowitz/.asdf/installs/python/3.10.7/lib/python3.10/site-packages/my_lib.py", "my_func") == "my_lib.my_func"
+        assert get_path("/Users/mikowitz/.asdf/installs/python/3.10.7/lib/python3.10/site-packages/my_lib.py", "my_func", "my.prefix") == "my.prefix.my_lib.my_func"
+        assert get_path("/Users/mikowitz/Code/my_app/my_app/my_lib.py", "my_func") == "my_app.my_app.my_lib.my_func"
+
+    def test_get_severity(self, client):
+        config_client = client.config_client()
+
+        assert get_severity("", config_client) == Prefab.LogLevel.Value("WARN")
+        assert get_severity("app", config_client) == Prefab.LogLevel.Value("ERROR")
+        assert get_severity("app.controller", config_client) == Prefab.LogLevel.Value("ERROR")
+        assert get_severity("app.controller.hello", config_client) == Prefab.LogLevel.Value("WARN")
+        assert get_severity("app.controller.hello.index", config_client) == Prefab.LogLevel.Value("INFO")
+        assert get_severity("app.controller.hello.edit", config_client) == Prefab.LogLevel.Value("WARN")
+
+    def test_capture_output(self, client, capsys):
+        logger = client.logger()
+
+        logger.warn("ok")
+
+        captured = capsys.readouterr()
+        log_pattern = re.compile(".*warning.*ok.*")
+        location_pattern = re.compile(".*location.*=.*prefab_cloud_python.tests.test_logger_client.test_capture_output")
+        assert log_pattern.match(captured.out)
+        assert location_pattern.match(captured.out)
+
+    def test_no_output_for_lower_log_level(self, client, capsys):
+        logger = client.logger()
+
+        logger.debug("ok")
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_log_prefix_from_client(self, capsys):
+        options = Options(
+            prefab_config_classpath_dir="tests",
+            prefab_envs=["unit_tests"],
+            prefab_datasources="LOCAL_ONLY",
+            log_prefix="my.prefix"
+
+        )
+        client = Client(options)
+
+        logger = client.logger()
+
+        logger.warn("ok")
+
+        captured = capsys.readouterr()
+        log_pattern = re.compile(".*warning.*ok.*")
+        location_pattern = re.compile(".*location.*=.*my.prefix.prefab_cloud_python.tests.test_logger_client.test_log_prefix_from_client")
+        assert log_pattern.match(captured.out)
+        assert location_pattern.match(captured.out)


### PR DESCRIPTION
Replaces the basic `logging` logger with a LoggerClient built on top of `structlog` that can filter logs based on call location and configured log level at that location.

It is called via `client.logger()` and accepts the same log levels as structlog: debug, info, warn, error, critical, e.g.

```python
client.logger().warn("warning")
```

output uses structlog's `event_dict` to record the call location, so output logs will look like

```python
<timestamp> [severity ]: message       location=my_log_prefix.my_module.my_func
```

See https://github.com/hynek/structlog for examples with the accurate syntax highlighting