### PR TITLE
Pass explicit format to structlog Timestamper

### DIFF
--- a/prefab_cloud_python/logger_client.py
+++ b/prefab_cloud_python/logger_client.py
@@ -9,7 +9,7 @@ structlog.configure(
         structlog.processors.add_log_level,
         structlog.processors.StackInfoRenderer(),
         structlog.dev.set_exc_info,
-        structlog.processors.TimeStamper(),
+        structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=False),
         structlog.processors.CallsiteParameterAdder(
             [
                 structlog.processors.CallsiteParameter.PATHNAME,


### PR DESCRIPTION
Pass explicit format to structlog Timestamper

Without this, we were just getting a nigh-unreadable Unix timestamp.

**BEFORE**
![Screen Shot 2023-04-07 at 11 48 33 PM](https://user-images.githubusercontent.com/28326/230701908-c95c9d31-5e3b-41de-9a2d-2ac272d88d2c.png)

**AFTER** (this also required setting the timezone to `US/Eastern` in the Django app, instead of UTC. Which was a fun bug to figure out why setting `utc=False` here wasn't doing what it said it should...)
![Screen Shot 2023-04-07 at 11 58 08 PM](https://user-images.githubusercontent.com/28326/230702183-6e28b0e5-e11a-4ec0-9907-f4aa7cff1156.png)

