### PR TITLE
Add a `log_boundary` parameter to `Options` to keep log locations from getting out of control

### DIFF
--- a/prefab_cloud_python/_processors.py
+++ b/prefab_cloud_python/_processors.py
@@ -31,12 +31,16 @@ def clean_event_dict(_, __, event_dict):
     event_dict.pop("func_name")
     event_dict.pop("config_client")
     event_dict.pop("log_prefix")
+    event_dict.pop("log_boundary")
     return event_dict
 
 
 def set_location(_, __, event_dict):
     event_dict["location"] = get_path(
-        event_dict["pathname"], event_dict["func_name"], event_dict["log_prefix"]
+        event_dict["pathname"],
+        event_dict["func_name"],
+        event_dict["log_prefix"],
+        event_dict["log_boundary"],
     )
     return event_dict
 
@@ -66,12 +70,15 @@ def get_severity(location, config_client):
     return prefab_to_python_log_levels[closest_log_level]
 
 
-def get_path(path, func_name, prefix=None):
+def get_path(path, func_name, prefix=None, log_boundary=None):
     if "site-packages" in path:
         path = path.split("site-packages/")[-1]
     else:
-        path = path.replace(os.environ.get("HOME") + "/", "")
-        path = path.split("/")[-3:]
+        if log_boundary is not None:
+            path = path.replace(log_boundary, "")
+        else:
+            path = path.replace(os.environ.get("HOME"), "")
+        path = [segment for segment in path.split("/") if segment]
         path = ".".join(path)
 
     path = path.lower()

--- a/prefab_cloud_python/client.py
+++ b/prefab_cloud_python/client.py
@@ -60,4 +60,4 @@ class Client:
 
     @functools.cache
     def logger(self):
-        return LoggerClient(self.options.log_prefix)
+        return LoggerClient(self.options.log_prefix, self.options.log_boundary)

--- a/prefab_cloud_python/logger_client.py
+++ b/prefab_cloud_python/logger_client.py
@@ -34,8 +34,9 @@ class BootstrappingConfigClient:
 
 
 class LoggerClient:
-    def __init__(self, log_prefix=None):
+    def __init__(self, log_prefix=None, log_boundary=None):
         self.log_prefix = log_prefix
+        self.log_boundary = log_boundary
         self.config_client = BootstrappingConfigClient()
 
     def debug(self, msg):
@@ -62,5 +63,7 @@ class LoggerClient:
 
     def configured_logger(self):
         return structlog.get_logger().bind(
-            config_client=self.config_client, log_prefix=self.log_prefix
+            config_client=self.config_client,
+            log_prefix=self.log_prefix,
+            log_boundary=self.log_boundary,
         )

--- a/prefab_cloud_python/options.py
+++ b/prefab_cloud_python/options.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from urllib.parse import urlparse
 
 
@@ -39,6 +40,7 @@ class Options:
         prefab_datasources=None,
         logdev="STDIO",
         log_prefix=None,
+        log_boundary=None,
         namespace="",
         connection_timeout_seconds=10,
         prefab_config_override_dir=os.environ.get("HOME"),
@@ -60,6 +62,10 @@ class Options:
         )
         self.logdev = logdev
         self.log_prefix = log_prefix
+        if log_boundary is not None:
+            self.log_boundary = str(Path(log_boundary).resolve())
+        else:
+            self.log_boundary = None
         self.namespace = namespace
         self.connection_timeout_seconds = connection_timeout_seconds
         self.prefab_config_override_dir = prefab_config_override_dir


### PR DESCRIPTION
For libraries that are not being used from a regular install of Python,
and so are not in a `site-packages` directory, the location string would
be the entire path to the callsite, minus `$HOME`, which could
potentially be a very long string with a lot of useless information.

This introduces the `log_boundary` parameter that, if present, is used
over `$HOME` to truncate the callsite while generating logger metadata
