### PR TITLE
Ensure `ConfigClient#get` properly passes the lookup key to the value unwrapper

### DIFF
--- a/prefab_cloud_python/config_client.py
+++ b/prefab_cloud_python/config_client.py
@@ -62,7 +62,9 @@ class ConfigClient:
     def get(self, key, default="NO_DEFAULT_PROVIDED", properties={}, lookup_key=None):
         value = self.__get(key, lookup_key, properties)
         if value is not None:
-            return ConfigValueUnwrapper.unwrap(value, key, properties)
+            return ConfigValueUnwrapper.unwrap(
+                value, key, properties | {"LOOKUP": lookup_key}
+            )
         else:
             return self.handle_default(key, default)
 

--- a/prefab_cloud_python/criteria_evaluator.py
+++ b/prefab_cloud_python/criteria_evaluator.py
@@ -22,7 +22,6 @@ class CriteriaEvaluator:
         return None
 
     def all_criteria_match(self, conditional_value, props):
-        # all(conditional_value.criteria,
         for criterion in conditional_value.criteria:
             if not self.evaluate_criterion(criterion, props):
                 return False


### PR DESCRIPTION
Before this change, the lookup key was not being passed to the value unwrapper, meaning that for percentage rollouts, there was no sticky key to use for hashing, leading to inconsistent results when calling a flag with a percentage rollout, even when passing the same lookup key each time.
