### PR TITLE
Bump to version 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.3.2] - 2023-06-20
+
+- Allow using latest urllib 1.x version to avoid forcing users to upgrade to urllib 2+
+
 ## [0.3.1] - 2023-06-12
 
 - Ensure `LoggerClient.config_client` is not set until the config client has initialized successfully

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prefab-cloud-python"
-version = "0.3.1"
+version = "0.3.2"
 description = "Python client for Prefab Feature Flags, Dynamic log levels, and Config as a Service: https://www.prefab.cloud"
 license = "MIT"
 authors = ["Michael Berkowitz <michael.berkowitz@gmail.com>"]


### PR DESCRIPTION
Allow using latest urllib 1.x version to avoid forcing users to upgrade to urllib 2+