### PR TITLE
base_client.logger is not callable

### DIFF
--- a/prefab_cloud_python/config_client.py
+++ b/prefab_cloud_python/config_client.py
@@ -76,7 +76,7 @@ class ConfigClient:
                 raise InitializationTimeoutException(
                     self.options.connection_timeout_seconds, key
                 )
-            self.base_client.logger().warn(
+            self.base_client.logger.warn(
                 f"Couldn't initialize in {self.options.connection_timeout_seconds}. Key {key}. Returning what we have."
             )
             self.init_lock.release_write()


### PR DESCRIPTION
we should look into introducing type annotations so that the IDE catches these things for us