### PR TITLE
don't parse non-dict yaml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Better handling for non-valid yaml in YamlParser
+
 ## [0.3.3] - 2023-06-21
 
 - Move `pytest` and `timecop` to dev dependencies

--- a/prefab_cloud_python/config_loader.py
+++ b/prefab_cloud_python/config_loader.py
@@ -53,14 +53,12 @@ class ConfigLoader:
         loaded_config = {}
         for env in envs:
             loaded_config.update(
-                ConfigLoader.__load_glob(
-                    os.path.join(dir, ".prefab.%s.config.yaml" % env)
-                )
+                self.__load_glob(os.path.join(dir, ".prefab.%s.config.yaml" % env))
             )
         return loaded_config
 
-    def __load_glob(filepath):
+    def __load_glob(self, filepath):
         rtn = {}
         for file in glob.glob(filepath):
-            rtn = rtn | YamlParser(file).data
+            rtn = rtn | YamlParser(file, self.base_client).data
         return rtn

--- a/prefab_cloud_python/yaml_parser.py
+++ b/prefab_cloud_python/yaml_parser.py
@@ -3,15 +3,27 @@ import yaml
 
 
 class YamlParser:
-    def __init__(self, filename):
+    def __init__(self, filename: str, base_client=None) -> None:
         self.filename = filename
+        self.base_client = base_client
+        self.data = {}
         self.parse()
 
     def parse(self):
-        f = open(self.filename, "r")
-        yaml_data = yaml.safe_load(f.read())
-        config = {}
-        for key in yaml_data:
-            config = ConfigParser.parse(key, yaml_data[key], config, self.filename)
-        f.close()
-        self.data = config
+        try:
+            with open(self.filename, "r") as f:
+                yaml_data = yaml.safe_load(f.read())
+                if not yaml_data or not isinstance(yaml_data, dict):
+                    return
+                config = {}
+                for key in yaml_data:
+                    config = ConfigParser.parse(
+                        key, yaml_data[key], config, self.filename
+                    )
+                self.data = config
+        except FileNotFoundError:
+            if self.base_client:
+                self.base_client.logger.log_internal(
+                    "warn", f"YamlParser could not find {self.filename} to parse"
+                )
+            return

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -1,0 +1,37 @@
+from prefab_cloud_python.yaml_parser import YamlParser
+from prefab_cloud_python.config_parser import ConfigParser
+import os
+
+TEST_FILENAME = "yaml_parser_test.yml"
+
+VALID_CONTENTS = """
+---
+name: "michael"
+"""
+
+INVALID_CONTENTS = """
+hello
+"""
+
+
+class TestYamlParser:
+    def test_valid_file(self):
+        with open(TEST_FILENAME, "w") as f:
+            f.write(VALID_CONTENTS)
+
+        parser = YamlParser(TEST_FILENAME)
+        expected_data = ConfigParser.parse("name", "michael", {}, TEST_FILENAME)
+        assert parser.data == expected_data
+        os.remove(TEST_FILENAME)
+
+    def test_invalid_file(self):
+        with open(TEST_FILENAME, "w") as f:
+            f.write(INVALID_CONTENTS)
+
+        parser = YamlParser(TEST_FILENAME)
+        assert parser.data == {}
+        os.remove(TEST_FILENAME)
+
+    def test_non_existent_file(self):
+        parser = YamlParser(TEST_FILENAME)
+        assert parser.data == {}


### PR DESCRIPTION
A blank or non-dict `.prefab.default.config.yaml` file causes the client to throw an exception:

```
semgrep-app-backend-1  |   File "/opt/venv/semgrep-app-9TtSrW0h-py3.11/lib/python3.11/site-packages/prefab_cloud_python/client.py", line 46, in __init__
semgrep-app-backend-1  |     self.config_client()
semgrep-app-backend-1  |   File "/opt/venv/semgrep-app-9TtSrW0h-py3.11/lib/python3.11/site-packages/prefab_cloud_python/client.py", line 86, in config_client
semgrep-app-backend-1  |     client = ConfigClient(self, timeout=5.0)
semgrep-app-backend-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
semgrep-app-backend-1  |   File "/opt/venv/semgrep-app-9TtSrW0h-py3.11/lib/python3.11/site-packages/prefab_cloud_python/config_client.py", line 45, in __init__
semgrep-app-backend-1  |     self.config_loader = ConfigLoader(base_client)
semgrep-app-backend-1  |                          ^^^^^^^^^^^^^^^^^^^^^^^^^
semgrep-app-backend-1  |   File "/opt/venv/semgrep-app-9TtSrW0h-py3.11/lib/python3.11/site-packages/prefab_cloud_python/config_loader.py", line 12, in __init__
semgrep-app-backend-1  |     self.__load_classpath_config()
semgrep-app-backend-1  |   File "/opt/venv/semgrep-app-9TtSrW0h-py3.11/lib/python3.11/site-packages/prefab_cloud_python/config_loader.py", line 44, in __load_classpath_config
semgrep-app-backend-1  |     self.classpath_config = self.__load_config_from(classpath_dir)
semgrep-app-backend-1  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
semgrep-app-backend-1  |   File "/opt/venv/semgrep-app-9TtSrW0h-py3.11/lib/python3.11/site-packages/prefab_cloud_python/config_loader.py", line 56, in __load_config_from
semgrep-app-backend-1  |     ConfigLoader.__load_glob(
semgrep-app-backend-1  |   File "/opt/venv/semgrep-app-9TtSrW0h-py3.11/lib/python3.11/site-packages/prefab_cloud_python/config_loader.py", line 65, in __load_glob
semgrep-app-backend-1  |     rtn = rtn | YamlParser(file).data
semgrep-app-backend-1  |                 ^^^^^^^^^^^^^^^^
semgrep-app-backend-1  |   File "/opt/venv/semgrep-app-9TtSrW0h-py3.11/lib/python3.11/site-packages/prefab_cloud_python/yaml_parser.py", line 8, in __init__
semgrep-app-backend-1  |     self.parse()
semgrep-app-backend-1  |   File "/opt/venv/semgrep-app-9TtSrW0h-py3.11/lib/python3.11/site-packages/prefab_cloud_python/yaml_parser.py", line 14, in parse
semgrep-app-backend-1  |     for key in yaml_data:
semgrep-app-backend-1  | TypeError: 'NoneType' object is not iterable
```