### PR TITLE
Start typing the client

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,9 +31,21 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-        exclude: ^prefab_pb2.*\.py$
+        exclude: ^prefab_pb2.*\.pyi?$
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
     hooks:
       - id: prettier
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.4.1
+    hooks:
+      - id: mypy
+        language_version: python3.10
+        # TODO: remove next two lines once module has been typed
+        args: ["."]
+        pass_filenames: false
+        additional_dependencies:
+          - types-protobuf
+          - types-pyyaml

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,80 @@
+
+[mypy]
+# Globals
+python_version = 3.10
+
+# TODO: remove this line once the entire module is typed
+follow_imports = skip
+
+# TODO: remove file(s) from exclude line(s) as they get typed
+exclude = (?x)(
+        ^prefab_cloud_python/config_loader\.py$
+        | ^prefab_cloud_python/config_parser\.py$
+        | ^prefab_cloud_python/logger_client\.py$
+        | ^prefab_cloud_python/client\.py$
+        | ^prefab_cloud_python/weighted_value_resolver\.py$
+        | ^prefab_cloud_python/context_shape_aggregator\.py$
+        | ^prefab_cloud_python/__init__\.py$
+        | ^prefab_cloud_python/criteria_evaluator\.py$
+        | ^prefab_cloud_python/context_shape\.py$
+        | ^prefab_cloud_python/log_path_aggregator\.py$
+        | ^prefab_cloud_python/config_value_unwrapper\.py$
+        | ^prefab_cloud_python/context\.py$
+        | ^prefab_cloud_python/feature_flag_client\.py$
+        | ^prefab_cloud_python/config_resolver\.py$
+        | ^prefab_cloud_python/_processors\.py$
+        | ^prefab_cloud_python/read_write_lock\.py$
+        | ^prefab_cloud_python/yaml_parser\.py$
+        | ^prefab_cloud_python/config_client\.py$
+        | ^tests/test_config_parser\.py$
+        | ^tests/test_weighted_value_resolver\.py$
+        | ^tests/test_log_path_aggregator\.py$
+        | ^tests/test_config_loader\.py$
+        | ^tests/test_options\.py$
+        | ^tests/test_config_value_unwrapper\.py$
+        | ^tests/test_context_shape\.py$
+        | ^tests/__init__\.py$
+        | ^tests/test_logger_client\.py$
+        | ^tests/test_yaml_parser\.py$
+        | ^tests/test_context_shape_aggregator\.py$
+        | ^tests/test_criteria_evaluator\.py$
+        | ^tests/test_context\.py$
+        | ^tests/test_integration\.py$
+        | ^tests/test_feature_flag_client\.py$
+        | ^tests/test_client\.py$
+        | ^tests/test_config_client\.py$
+        | ^prefab_pb2.*\.pyi?$
+    )
+
+# Strict typing options
+# The options below enforce strict typings for MyPy and explicitly list out the option
+# flags for the MyPy `--strict` flag
+# Goal is to make this as close as possible to the TypeScript `strict` tsconfig.json flag
+
+# Avoid configuration issues
+warn_unused_configs = True
+
+# Dynamic typing
+disallow_subclassing_any = False
+disallow_any_generics = False
+
+# Untyped definitions and calls
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = False
+
+# Implicit optional
+no_implicit_optional = True
+
+# Other warns
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = False
+
+# Misc flags. Aren't enabled by --strict by default
+disallow_any_unimported = False
+disallow_any_expr = False
+disallow_any_decorated = False
+disallow_any_explicit = False

--- a/poetry.lock
+++ b/poetry.lock
@@ -197,6 +197,63 @@ files = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.4.1"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mypy-1.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:566e72b0cd6598503e48ea610e0052d1b8168e60a46e0bfd34b3acf2d57f96a8"},
+    {file = "mypy-1.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ca637024ca67ab24a7fd6f65d280572c3794665eaf5edcc7e90a866544076878"},
+    {file = "mypy-1.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0dde1d180cd84f0624c5dcaaa89c89775550a675aff96b5848de78fb11adabcd"},
+    {file = "mypy-1.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8c4d8e89aa7de683e2056a581ce63c46a0c41e31bd2b6d34144e2c80f5ea53dc"},
+    {file = "mypy-1.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:bfdca17c36ae01a21274a3c387a63aa1aafe72bff976522886869ef131b937f1"},
+    {file = "mypy-1.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7549fbf655e5825d787bbc9ecf6028731973f78088fbca3a1f4145c39ef09462"},
+    {file = "mypy-1.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98324ec3ecf12296e6422939e54763faedbfcc502ea4a4c38502082711867258"},
+    {file = "mypy-1.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:141dedfdbfe8a04142881ff30ce6e6653c9685b354876b12e4fe6c78598b45e2"},
+    {file = "mypy-1.4.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8207b7105829eca6f3d774f64a904190bb2231de91b8b186d21ffd98005f14a7"},
+    {file = "mypy-1.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:16f0db5b641ba159eff72cff08edc3875f2b62b2fa2bc24f68c1e7a4e8232d01"},
+    {file = "mypy-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:470c969bb3f9a9efcedbadcd19a74ffb34a25f8e6b0e02dae7c0e71f8372f97b"},
+    {file = "mypy-1.4.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5952d2d18b79f7dc25e62e014fe5a23eb1a3d2bc66318df8988a01b1a037c5b"},
+    {file = "mypy-1.4.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:190b6bab0302cec4e9e6767d3eb66085aef2a1cc98fe04936d8a42ed2ba77bb7"},
+    {file = "mypy-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9d40652cc4fe33871ad3338581dca3297ff5f2213d0df345bcfbde5162abf0c9"},
+    {file = "mypy-1.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:01fd2e9f85622d981fd9063bfaef1aed6e336eaacca00892cd2d82801ab7c042"},
+    {file = "mypy-1.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2460a58faeea905aeb1b9b36f5065f2dc9a9c6e4c992a6499a2360c6c74ceca3"},
+    {file = "mypy-1.4.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2746d69a8196698146a3dbe29104f9eb6a2a4d8a27878d92169a6c0b74435b6"},
+    {file = "mypy-1.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:ae704dcfaa180ff7c4cfbad23e74321a2b774f92ca77fd94ce1049175a21c97f"},
+    {file = "mypy-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:43d24f6437925ce50139a310a64b2ab048cb2d3694c84c71c3f2a1626d8101dc"},
+    {file = "mypy-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c482e1246726616088532b5e964e39765b6d1520791348e6c9dc3af25b233828"},
+    {file = "mypy-1.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:43b592511672017f5b1a483527fd2684347fdffc041c9ef53428c8dc530f79a3"},
+    {file = "mypy-1.4.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:34a9239d5b3502c17f07fd7c0b2ae6b7dd7d7f6af35fbb5072c6208e76295816"},
+    {file = "mypy-1.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5703097c4936bbb9e9bce41478c8d08edd2865e177dc4c52be759f81ee4dd26c"},
+    {file = "mypy-1.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:e02d700ec8d9b1859790c0475df4e4092c7bf3272a4fd2c9f33d87fac4427b8f"},
+    {file = "mypy-1.4.1-py3-none-any.whl", hash = "sha256:45d32cec14e7b97af848bddd97d85ea4f0db4d5a149ed9676caa4eb2f7402bb4"},
+    {file = "mypy-1.4.1.tar.gz", hash = "sha256:9bbcd9ab8ea1f2e1c8031c21445b511442cc45c89951e49bbf852cbb70755b1b"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "packaging"
 version = "23.1"
 description = "Core utilities for Python packages"
@@ -381,6 +438,17 @@ files = [
 ]
 
 [[package]]
+name = "typing-extensions"
+version = "4.6.3"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "typing_extensions-4.6.3-py3-none-any.whl", hash = "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26"},
+    {file = "typing_extensions-4.6.3.tar.gz", hash = "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.0.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -400,4 +468,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.10, < 4"
-content-hash = "e61e761462986009cfaa2cf11f751e92cd76f04a649c38cd0ad235270873fa40"
+content-hash = "3a445d11ccbf5f727fdf1fd77b105d7e93f2f55dd34ee2a8856803f54ae17b34"

--- a/prefab_cloud_python/options.py
+++ b/prefab_cloud_python/options.py
@@ -4,56 +4,69 @@ from urllib.parse import urlparse
 
 
 class MissingApiKeyException(Exception):
-    "Raised when no API key is found"
+    """
+    Raised when no API key is found
+    """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("No API key found")
 
 
 class InvalidApiKeyException(Exception):
-    "Raised when an invalid API key is provided"
+    """
+    Raised when an invalid API key is provided
+    """
 
-    def __init__(self, api_key):
-        super().__init__("Invalid API key: %s" % api_key)
+    def __init__(self, api_key: str) -> None:
+        super().__init__(f"Invalid API key: {api_key}")
 
 
 class InvalidApiUrlException(Exception):
-    "Raised when an invalid API URL is given"
+    """
+    Raised when an invalid API URL is given
+    """
 
-    def __init__(self, url):
-        super().__init__("Invalid API URL found: %s" % url)
+    def __init__(self, url: str) -> None:
+        super().__init__(f"Invalid API URL found: {url}")
 
 
 class InvalidGrpcUrlException(Exception):
-    "Raised when an invalid gRPC URL is given"
+    """
+    Raised when an invalid gRPC URL is given
+    """
 
-    def __init__(self, url):
-        super().__init__("Invalid gRPC URL found: %s" % url)
+    def __init__(self, url: str) -> None:
+        super().__init__(f"Invalid gRPC URL found: {url}")
+
+
+VALID_DATASOURCES = ("LOCAL_ONLY", "ALL")
+VALID_ON_NO_DEFAULT = ("RAISE", "RETURN_NONE")
+VALID_ON_CONNECTION_FAILURE = ("RETURN", "RAISE")
 
 
 class Options:
     def __init__(
         self,
-        api_key=None,
-        prefab_api_url=None,
-        prefab_grpc_url=None,
-        prefab_datasources=None,
-        logdev="STDIO",
-        log_prefix=None,
-        log_boundary=None,
-        namespace="",
-        connection_timeout_seconds=10,
-        prefab_config_override_dir=os.environ.get("HOME"),
-        prefab_config_classpath_dir=".",
-        prefab_envs=[],
-        http_secure=None,
-        on_no_default="RAISE",
-        on_connection_failure="RETURN",
-        collect_logs=True,
-        collect_max_paths=1000,
-        collect_max_shapes=10_000,
-        collect_sync_interval=None,
-    ):
+        api_key: str | None = None,
+        prefab_api_url: str | None = None,
+        prefab_grpc_url: str | None = None,
+        prefab_datasources: str | None = None,
+        logdev: str = "STDIO",
+        log_prefix: str | None = None,
+        log_boundary: str | None = None,
+        namespace: str = "",
+        connection_timeout_seconds: int = 10,
+        prefab_config_override_dir: str | None = os.environ.get("HOME"),
+        prefab_config_classpath_dir: str = ".",
+        prefab_envs: list[str] = [],
+        http_secure: bool | None = None,
+        on_no_default: str = "RAISE",
+        on_connection_failure: str = "RETURN",
+        collect_logs: bool = True,
+        collect_max_paths: int = 1000,
+        collect_max_shapes: int = 10_000,
+        collect_sync_interval: int | None = None,
+    ) -> None:
         self.prefab_datasources = Options.__validate_datasource(prefab_datasources)
         self.__set_api_key(api_key or os.environ.get("PREFAB_API_KEY"))
         self.__set_api_url(
@@ -66,10 +79,7 @@ class Options:
         )
         self.logdev = logdev
         self.log_prefix = log_prefix
-        if log_boundary is not None:
-            self.log_boundary = str(Path(log_boundary).resolve())
-        else:
-            self.log_boundary = None
+        self.log_boundary = str(Path(log_boundary).resolve()) if log_boundary else None
         self.namespace = namespace
         self.connection_timeout_seconds = connection_timeout_seconds
         self.prefab_config_override_dir = prefab_config_override_dir
@@ -85,33 +95,36 @@ class Options:
         self.collect_sync_interval = collect_sync_interval
         self.collect_max_shapes = collect_max_shapes
 
-    def is_local_only(self):
+    def is_local_only(self) -> bool:
         return self.prefab_datasources == "LOCAL_ONLY"
 
-    def __set_url_for_api_cdn(self):
+    def __set_url_for_api_cdn(self) -> None:
         if self.prefab_datasources == "LOCAL_ONLY":
             self.url_for_api_cdn = None
         else:
             cdn_url_from_env = os.environ.get("PREFAB_CDN_URL")
             if cdn_url_from_env is not None:
                 self.url_for_api_cdn = cdn_url_from_env
-            else:
+            elif self.prefab_api_url:
                 self.url_for_api_cdn = (
                     self.prefab_api_url.replace(".", "-") + ".global.ssl.fastly.net"
                 )
+            else:
+                self.url_for_api_cdn = None  # TODO: should we warn?
 
-    def __validate_datasource(datasource):
+    @staticmethod
+    def __validate_datasource(datasource: str | None) -> str:
         if os.getenv("PREFAB_DATASOURCES") == "LOCAL_ONLY":
             default = "LOCAL_ONLY"
         else:
             default = "ALL"
 
-        if datasource in ["LOCAL_ONLY", "ALL"]:
+        if datasource in VALID_DATASOURCES:
             return datasource
         else:
             return default
 
-    def __set_api_key(self, api_key):
+    def __set_api_key(self, api_key: str | None) -> None:
         if self.prefab_datasources == "LOCAL_ONLY":
             self.api_key = None
             return
@@ -123,7 +136,7 @@ class Options:
             raise InvalidApiKeyException(api_key)
         self.api_key = api_key
 
-    def __set_api_url(self, api_url):
+    def __set_api_url(self, api_url: str | None) -> None:
         if self.prefab_datasources == "LOCAL_ONLY":
             self.prefab_api_url = None
             return
@@ -135,7 +148,7 @@ class Options:
         else:
             raise InvalidApiUrlException(api_url)
 
-    def __set_grpc_url(self, grpc_url):
+    def __set_grpc_url(self, grpc_url: str | None) -> None:
         if self.prefab_datasources == "LOCAL_ONLY":
             self.prefab_grpc_url = None
             return
@@ -146,33 +159,37 @@ class Options:
         else:
             raise InvalidGrpcUrlException(grpc_url)
 
-    def __construct_prefab_envs(envs_from_input):
-        all_envs = Options.__parse_envs(envs_from_input) + Options.__parse_envs(
+    @classmethod
+    def __construct_prefab_envs(cls, envs_from_input: list[str]) -> list[str]:
+        all_envs = cls.__parse_envs(envs_from_input) + cls.__parse_envs(
             os.environ.get("PREFAB_ENVS")
         )
         all_envs.sort()
         return all_envs
 
-    def __parse_envs(envs):
+    @staticmethod
+    def __parse_envs(envs: list[str] | str | None) -> list[str]:
         if isinstance(envs, list):
             return envs
         if isinstance(envs, str):
             return [env.strip() for env in envs.split(",")]
         return []
 
-    def __set_on_no_default(self, input):
-        if input in ["RAISE", "RETURN_NONE"]:
-            self.on_no_default = input
+    def __set_on_no_default(self, value: str) -> None:
+        if value in VALID_ON_NO_DEFAULT:
+            self.on_no_default = value
         else:
             self.on_no_default = "RAISE"
 
-    def __set_on_connection_failure(self, input):
-        if input in ["RETURN", "RAISE"]:
-            self.on_connection_failure = input
+    def __set_on_connection_failure(self, value: str) -> None:
+        if value in VALID_ON_CONNECTION_FAILURE:
+            self.on_connection_failure = value
         else:
             self.on_connection_failure = "RETURN"
 
-    def __set_log_collection(self, collect_logs, collect_max_paths, is_local_only):
+    def __set_log_collection(
+        self, collect_logs: bool, collect_max_paths: int, is_local_only: bool
+    ) -> None:
         self.collect_logs = collect_logs
         if not collect_logs or is_local_only:
             self.collect_max_paths = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ sseclient-py = "^1.7.2"
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.1"
 timecop = "^0.5.0dev"
+mypy = "^1.4.1"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR:
- Adds `mypy` as a dev dependency and pre-commit hook
- Configures `mypy` to enforce typing on `options.py` (typed in this PR) and any _new_ files
- Adds typing to `options.py` (+ some minor refactoring)

Next steps:
- Add types to the other files in the module (remove each file from the exclusion list as it's typed)

Don't bother cutting a new release until all the typing work is done (but no harm in releasing if other changes need to be published)