### PR TITLE
Move the structlog config into LoggerClient.__init__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Configure `structlog` for the LoggerClient less eagerly
+
 ## [0.5.1] - 2023-06-28
 
 - Migrate from a direct dependency on `urllib3` to using `requests`


### PR DESCRIPTION
Configure structlog less eagerly so the prefab configuration doesn't clobber structlog configuration for other modules used alongside prefab, by setting the structlog processors only on the Prefab logger structlog instance, rather than globally.

A better solution might be to allow users to drop in their own desired log configuration (or hook into structlog/logger configuration elsewhere in their project), but that is a larger project out of scope for this PR, so while we work on that, this should allow users to not worry about prefab overwriting any other logger configuration they may have.
