### PR TITLE
Add support for reading config from a local JSON datafile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add support for reading config from a local JSON datafile
+
 ## [0.8.0] - 2024-01-12
 
 - Add support for `provided` config values via ENV vars

--- a/prefab_cloud_python/config_client.py
+++ b/prefab_cloud_python/config_client.py
@@ -62,6 +62,8 @@ class ConfigClient:
 
         if self.options.is_local_only():
             self.finish_init("local only")
+        elif self.options.has_datafile():
+            self.load_json_file(self.options.datafile)
         else:
             self.load_checkpoint()
             self.start_checkpointing_thread()
@@ -226,6 +228,11 @@ class ConfigClient:
         except OSError as e:
             self.base_client.logger.log_internal("info", e)
             return False
+
+    def load_json_file(self, datafile):
+        with open(datafile) as f:
+            configs = Parse(f.read(), Prefab.Configs())
+            self.load_configs(configs, "datafile")
 
     def finish_init(self, source):
         if not self.init_lock._write_locked:

--- a/prefab_cloud_python/config_loader.py
+++ b/prefab_cloud_python/config_loader.py
@@ -9,8 +9,8 @@ class ConfigLoader:
         self.base_client = base_client
         self.options = base_client.options
         self.highwater_mark = 0
-        self.__load_classpath_config()
-        self.__load_local_overrides()
+        self.classpath_config = self.__load_classpath_config()
+        self.local_overrides = self.__load_local_overrides()
         self.api_config = {}
 
     def calc_config(self):
@@ -40,12 +40,16 @@ class ConfigLoader:
         return configs
 
     def __load_classpath_config(self):
+        if self.options.has_datafile():
+            return {}
         classpath_dir = self.options.prefab_config_classpath_dir
-        self.classpath_config = self.__load_config_from(classpath_dir)
+        return self.__load_config_from(classpath_dir)
 
     def __load_local_overrides(self):
+        if self.options.has_datafile():
+            return {}
         override_dir = self.options.prefab_config_override_dir
-        self.local_overrides = self.__load_config_from(override_dir)
+        return self.__load_config_from(override_dir)
 
     def __load_config_from(self, dir):
         envs = self.options.prefab_envs

--- a/prefab_cloud_python/options.py
+++ b/prefab_cloud_python/options.py
@@ -64,12 +64,14 @@ class Options:
         on_no_default: str = "RAISE",
         on_connection_failure: str = "RETURN",
         x_use_local_cache: bool = False,
+        x_datafile: Optional[str] = None,
         collect_logs: bool = True,
         collect_max_paths: int = 1000,
         collect_max_shapes: int = 10_000,
         collect_sync_interval: Optional[int] = None,
     ) -> None:
         self.prefab_datasources = Options.__validate_datasource(prefab_datasources)
+        self.datafile = x_datafile
         self.__set_api_key(api_key or os.environ.get("PREFAB_API_KEY"))
         self.__set_api_url(
             prefab_api_url
@@ -101,6 +103,9 @@ class Options:
     def is_local_only(self) -> bool:
         return self.prefab_datasources == "LOCAL_ONLY"
 
+    def has_datafile(self) -> bool:
+        return self.datafile is not None
+
     def __set_url_for_api_cdn(self) -> None:
         if self.prefab_datasources == "LOCAL_ONLY":
             self.url_for_api_cdn = None
@@ -128,7 +133,7 @@ class Options:
             return default
 
     def __set_api_key(self, api_key: Optional[str]) -> None:
-        if self.prefab_datasources == "LOCAL_ONLY":
+        if self.is_local_only() or self.has_datafile():
             self.api_key = None
             self.api_key_id = "local"
             return

--- a/tests/prefab.datafile.json
+++ b/tests/prefab.datafile.json
@@ -1,0 +1,25 @@
+{
+  "configs": [
+    {
+      "id": "1",
+      "projectId": "350",
+      "key": "foo.str",
+      "changedBy": {
+        "email": "michael.berkowitz@gmail.com"
+      },
+      "rows": [
+        {
+          "values": [
+            {
+              "value": {
+                "string": "hello!"
+              }
+            }
+          ]
+        }
+      ],
+      "configType": "CONFIG",
+      "valueType": "STRING"
+    }
+  ]
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -37,6 +37,11 @@ class TestClient:
 
         assert client.get("missing_value") is None
 
+    def test_loading_from_datafile(self):
+        options = Options(x_datafile="tests/prefab.datafile.json")
+        client = Client(options)
+        assert client.get("foo.str") == "hello!"
+
     def test_enabled(self, client):
         assert not client.enabled("does_not_exist")
         assert client.enabled("enabled_flag")


### PR DESCRIPTION
* Allow passing a local JSON datafile into `Options()` via the `x_datafile` key
* Will load from the aforementioned datafile if provided
