### PR TITLE
Add setting default context on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Add support for reading config from a local JSON datafile
+- Add support for reading config from a local JSON datafile [#42]
+- Add support for setting and using default contexts [#43]
 
 ## [0.8.0] - 2024-01-12
 

--- a/prefab_cloud_python/config_client.py
+++ b/prefab_cloud_python/config_client.py
@@ -183,6 +183,17 @@ class ConfigClient:
         project_env_id = configs.config_service_pointer.project_env_id
         self.config_resolver.project_env_id = project_env_id
         starting_highwater_mark = self.config_loader.highwater_mark
+
+        default_contexts = {}
+        if configs.default_context and configs.default_context.contexts is not None:
+            for context in configs.default_context.contexts:
+                values = {}
+                for k, v in context.values.items():
+                    values[k] = ConfigValueUnwrapper(v, self.config_resolver).unwrap()
+                default_contexts[context.type] = values
+
+        self.config_resolver.default_context = default_contexts
+
         for config in configs.configs:
             self.config_loader.set(config, source)
         if self.config_loader.highwater_mark > starting_highwater_mark:

--- a/prefab_cloud_python/config_resolver.py
+++ b/prefab_cloud_python/config_resolver.py
@@ -9,6 +9,7 @@ class ConfigResolver:
         self.base_client = base_client
         self.config_loader = config_loader
         self.project_env_id = 0
+        self.default_context = {}
         self.make_local()
 
     def get(self, key, context=Context.get_current()):
@@ -35,10 +36,9 @@ class ConfigResolver:
         ).evaluate(self.evaluation_context(context))
 
     def evaluation_context(self, context):
-        if isinstance(context, Context):
-            return context
-        else:
-            return Context.merge_with_current(context)
+        if not isinstance(context, Context):
+            context = Context.merge_with_current(context)
+        return context.merge_default(self.default_context)
 
     def update(self):
         self.make_local()
@@ -47,3 +47,11 @@ class ConfigResolver:
         self.lock.acquire_write()
         self.local_store = self.config_loader.calc_config()
         self.lock.release_write()
+
+    @property
+    def default_context(self):
+        return self._default_context
+
+    @default_context.setter
+    def default_context(self, value):
+        self._default_context = value

--- a/prefab_cloud_python/context.py
+++ b/prefab_cloud_python/context.py
@@ -56,6 +56,12 @@ class Context:
         original.merge(value)
         self.contexts[str(key)] = original
 
+    def merge_default(self, defaults):
+        for name in defaults.keys():
+            self.merge(name, defaults[name])
+
+        return self
+
     def clear(self):
         self.contexts = {}
 


### PR DESCRIPTION
Add code that reads `Configs.default_context` when loading configs and stores any content to `ConfigResolver.default_context`
