### PR TITLE
pin version of urllib to resolve vulnerability

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -826,18 +826,17 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.2"
+version = "2.1.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.0.2-py3-none-any.whl", hash = "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"},
-    {file = "urllib3-2.0.2.tar.gz", hash = "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc"},
+    {file = "urllib3-2.1.0-py3-none-any.whl", hash = "sha256:55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3"},
+    {file = "urllib3-2.1.0.tar.gz", hash = "sha256:df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54"},
 ]
 
 [package.extras]
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
-secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
@@ -864,4 +863,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.9, < 4"
-content-hash = "eb93c7f712c81a8e6cc6fdc53b361aeed41e63df04bdd8e991dfbe835b42bfc3"
+content-hash = "d81a292b51d0ef2c53971f0f346c28f70e344a4e13b6141d4ad9ac8eb44e1705"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ requests = "^2.30.0"
 structlog = "^22.3"
 sseclient-py = "^1.7.2"
 cachetools = "^5.3.0"
+urllib3 = ">= 2.0.7"
 
 [tool.poetry.group.dev.dependencies]
 grpcio-tools = ">= 1.48.4"


### PR DESCRIPTION
This is a replacement for the auto-generated PR #50 which only changed the do-not-edit poetry.lock file