### PR TITLE
Adds a close method

### DIFF
--- a/prefab_cloud_python/_telemetry.py
+++ b/prefab_cloud_python/_telemetry.py
@@ -107,7 +107,7 @@ class TelemetryManager(object):
         try:
             self.flush()
         finally:
-            if self.sync_started:
+            if self.sync_started and not self.client.shutdown_flag.is_set():
                 self.timer = threading.Timer(self.report_interval, self.run_sync)
                 self.timer.start()
 
@@ -338,7 +338,7 @@ class TelemetryEventProcessor(object):
             pass
 
     def process_queue(self):
-        while True:
+        while not self.base_client.shutdown_flag.is_set():
             event = self.queue.get()
             try:
                 if (

--- a/prefab_cloud_python/client.py
+++ b/prefab_cloud_python/client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 import functools
+import threading
+import logging
 
 from urllib3 import Retry
 
@@ -30,6 +32,7 @@ class Client:
     no_default_provided = "NO_DEFAULT_PROVIDED"
 
     def __init__(self, options: Options) -> None:
+        self.shutdown_flag = threading.Event()
         self.options = options
         self.instance_hash = str(uuid.uuid4())
         self.logger = LoggerClient(self.options.log_prefix, self.options.log_boundary)
@@ -146,3 +149,10 @@ class Client:
             prefix=self.options.log_prefix,
             log_boundary=self.options.log_boundary,
         )
+
+    def close(self) -> None:
+        if not self.shutdown_flag.is_set():
+            logging.info("Shutting down prefab client instance")
+            self.shutdown_flag.set()
+        else:
+            logging.warning("Close already called")

--- a/prefab_cloud_python/config_client.py
+++ b/prefab_cloud_python/config_client.py
@@ -147,7 +147,7 @@ class ConfigClient:
                 self.load_configs(configs, "sse_streaming")
 
     def checkpointing_loop(self):
-        while True:
+        while not self.base_client.shutdown_flag.is_set():
             try:
                 self.load_checkpoint()
                 time.sleep(self.checkpoint_freq_secs)
@@ -156,6 +156,7 @@ class ConfigClient:
 
     def load_checkpoint_from_api_cdn(self):
         url = "%s/api/v1/configs/0" % self.options.url_for_api_cdn
+        self.base_client.logger.log_internal("warn", f"Loading config from {url}")
         response = self.base_client.session.get(
             url, auth=("authuser", self.options.api_key)
         )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -99,4 +99,3 @@ class MockClientForPosts:
     def post(self, path: str, body: PostBodyType) -> requests.models.Response:
         self.posts.append((path, body))
         return responses.Response(status=200, method="POST", headers=[], url="")
-

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,4 @@
+import threading
 from collections import defaultdict
 
 import requests
@@ -90,6 +91,7 @@ class MockClientForPosts:
     def __init__(self):
         self.posts = []
         self.logger = LoggerClient()
+        self.shutdown_flag = threading.Event()
 
     def reset(self):
         self.posts.clear()
@@ -97,3 +99,4 @@ class MockClientForPosts:
     def post(self, path: str, body: PostBodyType) -> requests.models.Response:
         self.posts.append((path, body))
         return responses.Response(status=200, method="POST", headers=[], url="")
+


### PR DESCRIPTION
Will set a threading.Event shutdown flag so threads will stop gracefully

The client's daemon threads weren't stopping reliably in gunicorn so this adds a close method that can be called in the on_exit hook