### PR TITLE
Adds global_context as the first layer of context

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -58,6 +58,7 @@ exclude = (?x)(
         | ^tests/test_telemetry_context_accumulator\.py$
         | ^tests/test_telemetry_evaluation_rollup\.py$
         | ^tests/test_telemetry_manager\.py$
+        | ^tests/test_config_resolver\.py$
         | ^prefab_pb2.*\.pyi?$
     )
 

--- a/prefab_cloud_python/__init__.py
+++ b/prefab_cloud_python/__init__.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from .options import Options as Options
-from .context import Context as Context
 from .client import Client as Client
 from .logger_filter import LoggerFilter as LoggerFilter
 from importlib.metadata import version

--- a/prefab_cloud_python/_telemetry.py
+++ b/prefab_cloud_python/_telemetry.py
@@ -15,7 +15,8 @@ from prefab_pb2 import (
     ExampleContext as ProtoExampleContext,
     ExampleContexts,
 )
-from . import Context, Options
+from .context import Context
+from .options import Options
 from .config_resolver import Evaluation
 from collections import defaultdict
 

--- a/prefab_cloud_python/client.py
+++ b/prefab_cloud_python/client.py
@@ -23,7 +23,7 @@ import uuid
 import requests
 from urllib.parse import urljoin
 from importlib.metadata import version
-from .constants import NoDefaultProvided, ConfigValueType
+from .constants import NoDefaultProvided, ConfigValueType, ContextDictType
 from ._internal_constants import LOG_LEVEL_BASE_KEY
 
 PostBodyType = Union[Prefab.Loggers, Prefab.ContextShapes, Prefab.TelemetryEvents]
@@ -82,22 +82,18 @@ class Client:
         self,
         key: str,
         default: ConfigValueType = NoDefaultProvided,
-        context: Optional[dict | Context] = None,
+        context: Optional[ContextDictType | Context] = None,
     ) -> ConfigValueType:
         if self.is_ff(key):
-            return self.feature_flag_client().get(
-                key, default=default, context=self.resolve_context_argument(context)
-            )
+            return self.feature_flag_client().get(key, default=default, context=context)
         else:
-            return self.config_client().get(
-                key, default=default, context=self.resolve_context_argument(context)
-            )
+            return self.config_client().get(key, default=default, context=context)
 
     def enabled(
-        self, feature_name: str, context: Optional[dict | Context] = None
+        self, feature_name: str, context: Optional[ContextDictType | Context] = None
     ) -> bool:
         return self.feature_flag_client().feature_is_on_for(
-            feature_name, context=self.resolve_context_argument(context)
+            feature_name, context=context
         )
 
     def is_ff(self, key: str) -> bool:
@@ -130,15 +126,6 @@ class Client:
             return default
         finally:
             ReentrancyCheck.clear()
-
-    def resolve_context_argument(
-        self, context: Optional[dict | Context] = None
-    ) -> Context:
-        if isinstance(context, Context):
-            return context
-        if isinstance(context, dict):
-            return Context(context=context)
-        return Context.get_current()
 
     def context(self) -> Context:
         return Context.get_current()

--- a/prefab_cloud_python/config_client.py
+++ b/prefab_cloud_python/config_client.py
@@ -71,7 +71,7 @@ class ConfigClient:
         self,
         key,
         default=NoDefaultProvided,
-        context: Optional[dict | Context] = Context.get_current(),
+        context: Optional[dict | Context] = None,
     ):
         evaluation_result = self.__get(key, None, {}, context=context)
         if evaluation_result is not None:
@@ -85,7 +85,7 @@ class ConfigClient:
         key,
         lookup_key,
         properties,
-        context: Optional[dict | Context] = Context.get_current(),
+        context: Optional[dict | Context] = None,
     ) -> None | Evaluation:
         ok_to_proceed = self.init_latch.wait(
             timeout=self.options.connection_timeout_seconds
@@ -164,7 +164,7 @@ class ConfigClient:
 
     def load_checkpoint_from_api_cdn(self):
         url = "%s/api/v1/configs/0" % self.options.url_for_api_cdn
-        logger.warning(f"Loading config from {url}")
+        logger.info(f"Loading config from {url}")
         response = self.base_client.session.get(
             url, auth=("authuser", self.options.api_key)
         )

--- a/prefab_cloud_python/constants.py
+++ b/prefab_cloud_python/constants.py
@@ -2,3 +2,4 @@ from typing import Optional, Union
 
 NoDefaultProvided = object()
 ConfigValueType = Optional[Union[int, float, bool, str, list[str]]]
+ContextDictType = dict[str, dict[str, ConfigValueType]]

--- a/prefab_cloud_python/feature_flag_client.py
+++ b/prefab_cloud_python/feature_flag_client.py
@@ -13,12 +13,12 @@ class FeatureFlagClient:
         self.base_client = base_client
 
     def feature_is_on(
-        self, feature_name, context: Optional[dict | Context] = Context.get_current()
+        self, feature_name, context: Optional[dict | Context] = None
     ) -> bool:
         return self.feature_is_on_for(feature_name, context)
 
     def feature_is_on_for(
-        self, feature_name, context: Optional[dict | Context] = Context.get_current()
+        self, feature_name, context: Optional[dict | Context] = None
     ) -> bool:
         variant = self.base_client.config_client().get(
             feature_name, False, context=context
@@ -29,7 +29,7 @@ class FeatureFlagClient:
         self,
         feature_name,
         default=NoDefaultProvided,
-        context: Optional[dict | Context] = Context.get_current(),
+        context: Optional[dict | Context] = None,
     ) -> ConfigValueType:
         return self._get(feature_name, default=default, context=context)
 
@@ -37,7 +37,7 @@ class FeatureFlagClient:
         self,
         feature_name,
         default=NoDefaultProvided,
-        context: Optional[dict | Context] = Context.get_current(),
+        context: Optional[dict | Context] = None,
     ) -> ConfigValueType:
         return self.base_client.config_client().get(
             feature_name, default=default, context=context

--- a/prefab_cloud_python/options.py
+++ b/prefab_cloud_python/options.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import logging
 import os
 from enum import Enum
 from pathlib import Path
 from urllib.parse import urlparse
 from typing import Optional, Union
+
+from .context import Context
+from .constants import ContextDictType
 
 
 class MissingApiKeyException(Exception):
@@ -69,6 +74,7 @@ class Options:
         collect_evaluation_summaries: bool = True,
         context_upload_mode: ContextUploadMode = ContextUploadMode.PERIODIC_EXAMPLE,
         bootstrap_loglevel: Optional[int] = None,
+        global_context: Optional[ContextDictType | Context] = None,
     ) -> None:
         self.prefab_datasources = Options.__validate_datasource(prefab_datasources)
         self.datafile = x_datafile
@@ -103,6 +109,7 @@ class Options:
             or bootstrap_loglevel
             or logging.WARNING
         )
+        self.global_context = Context.normalize_context_arg(global_context)
 
     def is_local_only(self) -> bool:
         return self.prefab_datasources == "LOCAL_ONLY"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,7 +5,7 @@ import requests
 import responses
 
 import prefab_pb2 as Prefab
-from prefab_cloud_python import Context
+from prefab_cloud_python.context import Context
 from prefab_cloud_python.client import PostBodyType
 from prefab_cloud_python.config_resolver import CriteriaEvaluator
 

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -1,0 +1,125 @@
+import pytest
+
+from prefab_cloud_python import Options
+from prefab_cloud_python.config_resolver import ConfigResolver
+from prefab_cloud_python.context import Context
+
+
+class FakeConfigLoader:
+    def __init__(self):
+        pass
+
+    def calc_config(self):
+        return {}
+
+
+class FakeClient:
+    def __init__(self, options=None):
+        self.options = options
+
+
+class ConfigResolverFactoryFixture:
+    def __init__(self):
+        self.client = None
+
+    def create(self, global_context={}, default_context={}) -> ConfigResolver:
+        options = Options(
+            global_context=global_context, prefab_datasources="LOCAL_ONLY"
+        )
+        config_resolver = ConfigResolver(
+            FakeClient(options=options), FakeConfigLoader()
+        )
+        config_resolver.default_context = default_context
+        return config_resolver
+
+
+@pytest.fixture
+def config_resolver_factory():
+    return ConfigResolverFactoryFixture()
+
+
+class ContextMergingTests:
+    def test_empty_contexts(self, config_resolver_factory):
+        config_resolver = config_resolver_factory.create()
+        assert config_resolver.evaluation_context(None).to_dict() == {}
+
+    def test_global_context(self, config_resolver_factory):
+        global_context_dict = {
+            "flavor": {"key": "tart"},
+            "texture": {"key": "crunchy"},
+            "size": {"key": "medium"},
+        }
+        config_resolver = config_resolver_factory.create(
+            global_context=global_context_dict
+        )
+        assert config_resolver.evaluation_context(None).to_dict() == global_context_dict
+
+    def test_global_plus_default_context(self, config_resolver_factory):
+        global_context_dict = {
+            "flavor": {"key": "tart"},
+            "texture": {"key": "crunchy"},
+            "size": {"key": "medium"},
+        }
+        default_context_dict = {"flavor": {"key": "sweet"}, "color": {"key": "red"}}
+        config_resolver = config_resolver_factory.create(
+            global_context=global_context_dict, default_context=default_context_dict
+        )
+        assert config_resolver.evaluation_context(None).to_dict() == {
+            "flavor": {"key": "sweet"},
+            "color": {"key": "red"},
+            "texture": {"key": "crunchy"},
+            "size": {"key": "medium"},
+        }
+
+    def test_global_plus_default_plus_implicit_context_sources(
+        self, config_resolver_factory
+    ):
+        global_context_dict = {
+            "flavor": {"key": "tart", "scale": 5},
+            "texture": {"key": "crunchy"},
+            "size": {"key": "medium"},
+        }
+        default_context_dict = {
+            "flavor": {"key": "sweet", "scale": 2},
+            "color": {"key": "red"},
+        }
+        Context.set_current(
+            {"flavor": {"key": "sour", "scale": 10}, "gmo_status": {"key": "yes"}}
+        )
+
+        config_resolver = config_resolver_factory.create(
+            global_context=global_context_dict, default_context=default_context_dict
+        )
+        assert config_resolver.evaluation_context(None).to_dict() == {
+            "flavor": {"key": "sour", "scale": 10},
+            "color": {"key": "red"},
+            "texture": {"key": "crunchy"},
+            "size": {"key": "medium"},
+            "gmo_status": {"key": "yes"},
+        }
+
+    def test_all_context_sources(self, config_resolver_factory):
+        global_context_dict = {
+            "flavor": {"key": "tart", "scale": 5},
+            "texture": {"key": "crunchy"},
+            "size": {"key": "medium"},
+        }
+        default_context_dict = {
+            "flavor": {"key": "sweet", "scale": 2},
+            "color": {"key": "red"},
+        }
+        Context.set_current(
+            {"flavor": {"key": "sour", "scale": 10}, "gmo_status": {"key": "yes"}}
+        )
+        passed_context = {"flavor": {"key": "spicy", "scale": 9}}
+
+        config_resolver = config_resolver_factory.create(
+            global_context=global_context_dict, default_context=default_context_dict
+        )
+        assert config_resolver.evaluation_context(passed_context).to_dict() == {
+            "flavor": {"key": "spicy", "scale": 9},
+            "color": {"key": "red"},
+            "texture": {"key": "crunchy"},
+            "size": {"key": "medium"},
+            "gmo_status": {"key": "yes"},
+        }

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -94,6 +94,21 @@ class TestContext:
             "name": "Ted",
         }
 
+    def test_merge_dicts(self, setup):
+        context = Context(EXAMPLE_PROPERTIES)
+        assert context.to_dict() == EXAMPLE_PROPERTIES
+        context.merge_context_dict(
+            {
+                "user": {"key": "brand-new", "other": "different"},
+                "address": {"city": "New York"},
+            }
+        )
+        assert context.to_dict() == {
+            "user": {"key": "brand-new", "other": "different"},
+            "team": {"key": "abc", "plan": "pro"},
+            "address": {"city": "New York"},
+        }
+
     def test_with_context(self, setup):
         assert not Context.get_current().contexts
         context = Context(EXAMPLE_PROPERTIES)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from prefab_cloud_python import Options, Client, Context
+from prefab_cloud_python import Options, Client
+from prefab_cloud_python.context import Context
 import prefab_pb2 as Prefab
 from prefab_cloud_python.config_client import (
     InitializationTimeoutException,

--- a/tests/test_telemetry_context_accumulator.py
+++ b/tests/test_telemetry_context_accumulator.py
@@ -1,6 +1,6 @@
 import prefab_pb2 as Prefab
 
-from prefab_cloud_python import Context
+from prefab_cloud_python.context import Context
 from prefab_cloud_python._telemetry import ContextExampleAccumulator
 
 


### PR DESCRIPTION
Removes Context.current() as default arg all over the place, Fixes Context merging behavior