### PR TITLE
Add examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,13 +1,9 @@
 # Examples
 
-
 ## [Standard-logging](standard-logging/)
 
 Demonstrates prefab client managing log levels with standard python logging
 
-
 ## [Gunicorn](gunicorn/)
 
 Demonstrates using the gunicorn post_worker_init hook to reset the prefab client instance after the process has forked
-
-

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# Examples
+
+
+## [Standard-logging](standard-logging/)
+
+Demonstrates prefab client managing log levels with standard python logging
+
+
+## [Gunicorn](gunicorn/)
+
+Demonstrates using the gunicorn post_worker_init hook to reset the prefab client instance after the process has forked
+
+

--- a/examples/gunicorn/README.md
+++ b/examples/gunicorn/README.md
@@ -1,0 +1,23 @@
+## Gunicorn
+
+This example demonstrates support for gunicorn's forking worker model
+
+`poetry install --no-root`
+
+`poetry PREFAB_API_KEY=XXXXXXXX gunicorn -w 2 -c gunicorn_conf.py myapp:app`
+
+`http -v http://localhost:8000`
+
+
+
+### gunicorn_conf.py
+
+Demonstrates resetting the prefab client in the `post_worker_init` hook
+
+
+### test_app.py
+
+A simple get endpoint that will output the value of a config variable, demonstrating that live updates still work after the worker has forked
+
+
+

--- a/examples/gunicorn/README.md
+++ b/examples/gunicorn/README.md
@@ -8,16 +8,10 @@ This example demonstrates support for gunicorn's forking worker model
 
 `http -v http://localhost:8000`
 
-
-
 ### gunicorn_conf.py
 
 Demonstrates resetting the prefab client in the `post_worker_init` hook
 
-
 ### test_app.py
 
 A simple get endpoint that will output the value of a config variable, demonstrating that live updates still work after the worker has forked
-
-
-

--- a/examples/gunicorn/gunicorn_conf.py
+++ b/examples/gunicorn/gunicorn_conf.py
@@ -3,16 +3,20 @@ import logging
 import prefab_cloud_python
 from prefab_cloud_python import Options
 
+
 def on_starting(server):
     logging.warning("Starting server")
     prefab_cloud_python.set_options(Options(collect_sync_interval=5))
-    logging.warning(f"current value of 'foobar' is {prefab_cloud_python.get_client().get('foobar')}")
+    logging.warning(
+        f"current value of 'foobar' is {prefab_cloud_python.get_client().get('foobar')}"
+    )
+
 
 def post_worker_init(worker):
     # Initialize the client for each worker
     prefab_cloud_python.reset_instance()
 
+
 def on_exit(server):
     logging.warning("shutting down prefab")
     prefab_cloud_python.reset_instance()
-

--- a/examples/gunicorn/gunicorn_conf.py
+++ b/examples/gunicorn/gunicorn_conf.py
@@ -1,0 +1,18 @@
+import logging
+
+import prefab_cloud_python
+from prefab_cloud_python import Options
+
+def on_starting(server):
+    logging.warning("Starting server")
+    prefab_cloud_python.set_options(Options(collect_sync_interval=5))
+    logging.warning(f"current value of 'foobar' is {prefab_cloud_python.get_client().get('foobar')}")
+
+def post_worker_init(worker):
+    # Initialize the client for each worker
+    prefab_cloud_python.reset_instance()
+
+def on_exit(server):
+    logging.warning("shutting down prefab")
+    prefab_cloud_python.reset_instance()
+

--- a/examples/gunicorn/pyproject.toml
+++ b/examples/gunicorn/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "gunicorntest"
+version = "0.1.0"
+description = ""
+authors = ["James Kebinger <james.kebinger@prefab.cloud>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+gunicorn = "^21.2.0"
+prefab-cloud-python = {path = "../..", develop = true}
+cachetools = "5.3.2"
+protobuf = "^4.25.2"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/examples/gunicorn/test_app.py
+++ b/examples/gunicorn/test_app.py
@@ -1,0 +1,9 @@
+import prefab_cloud_python
+
+def app(environ, start_response):
+    output = f"value of 'test.config' is {prefab_cloud_python.get_client().config_client().get('test.config')}".encode()
+    start_response("200 OK", [
+        ("Content-Type", "text/plain"),
+        ("Content-Length", str(len(output)))
+    ])
+    return iter([output])

--- a/examples/gunicorn/test_app.py
+++ b/examples/gunicorn/test_app.py
@@ -1,9 +1,9 @@
 import prefab_cloud_python
 
+
 def app(environ, start_response):
     output = f"value of 'test.config' is {prefab_cloud_python.get_client().config_client().get('test.config')}".encode()
-    start_response("200 OK", [
-        ("Content-Type", "text/plain"),
-        ("Content-Length", str(len(output)))
-    ])
+    start_response(
+        "200 OK", [("Content-Type", "text/plain"), ("Content-Length", str(len(output)))]
+    )
     return iter([output])

--- a/examples/standard-logging/README.md
+++ b/examples/standard-logging/README.md
@@ -1,0 +1,17 @@
+## Standard Logging
+
+This demonstrates use of the prefab logging filter with standard logging. 
+
+
+`poetry install --no-root`
+
+`poetry PREFAB_API_KEY=XXXXXXXX python standard-logger-example.py`
+
+
+### standard-logger-example.py
+
+Contains a loop logging at different log levels - changing the log level of the `prefab.python.test.logger` in the prefab UI or CLI will quickly affect which log lines are shown.
+
+Also demonstrates use of the `on_ready_callback` to add the logging filter and lower the global log level to debug
+
+

--- a/examples/standard-logging/README.md
+++ b/examples/standard-logging/README.md
@@ -1,17 +1,13 @@
 ## Standard Logging
 
-This demonstrates use of the prefab logging filter with standard logging. 
-
+This demonstrates use of the prefab logging filter with standard logging.
 
 `poetry install --no-root`
 
 `poetry PREFAB_API_KEY=XXXXXXXX python standard-logger-example.py`
-
 
 ### standard-logger-example.py
 
 Contains a loop logging at different log levels - changing the log level of the `prefab.python.test.logger` in the prefab UI or CLI will quickly affect which log lines are shown.
 
 Also demonstrates use of the `on_ready_callback` to add the logging filter and lower the global log level to debug
-
-

--- a/examples/standard-logging/pyproject.toml
+++ b/examples/standard-logging/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "prefabclient-demo"
+version = "0.1.0"
+description = ""
+authors = ["James Kebinger <james.kebinger@prefab.cloud>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.9"
+prefab-cloud-python = {path = "../../", develop = true}
+cryptography = "^42.0.0"
+requests = "^2.31.0"
+
+
+[tool.poetry.scripts]
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/examples/standard-logging/standard-logger-example.py
+++ b/examples/standard-logging/standard-logger-example.py
@@ -4,6 +4,7 @@ import time
 import prefab_cloud_python
 from prefab_cloud_python import Options, LoggerFilter
 
+
 ###
 # This example shows logger configuration and printing a config value in a loop
 # to run set PREFAB_API_KEY
@@ -23,12 +24,15 @@ def main():
         logging.warning("Logger configured")
 
     logger = logging.getLogger("prefab.python.test.logger")
-    options = Options(bootstrap_loglevel=logging.DEBUG, on_ready_callback=configure_logger)
+    options = Options(
+        bootstrap_loglevel=logging.DEBUG, on_ready_callback=configure_logger
+    )
     prefab_cloud_python.set_options(options)
     while True:
         time.sleep(1)
         logger.warning(
-            f"value of `example-config` is {prefab_cloud_python.get_client().get('example-config', default='default value')}")
+            f"value of `example-config` is {prefab_cloud_python.get_client().get('example-config', default='default value')}"
+        )
         logger.error("ERROR message")
         logger.warning("WARN message")
         logger.info("INFO message")

--- a/examples/standard-logging/standard-logger-example.py
+++ b/examples/standard-logging/standard-logger-example.py
@@ -1,0 +1,39 @@
+import logging
+import sys
+import time
+import prefab_cloud_python
+from prefab_cloud_python import Options, LoggerFilter
+
+###
+# This example shows logger configuration and printing a config value in a loop
+# to run set PREFAB_API_KEY
+def main():
+    # basic logging setup
+    root_logger = logging.getLogger()
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    )
+    root_logger.addHandler(handler)
+
+    def configure_logger():
+        # add the prefab filter, lower the overall logging level to DEBUG so the filter can handle every log message
+        handler.addFilter(LoggerFilter())
+        logging.basicConfig(level=logging.DEBUG)
+        logging.warning("Logger configured")
+
+    logger = logging.getLogger("prefab.python.test.logger")
+    options = Options(bootstrap_loglevel=logging.DEBUG, on_ready_callback=configure_logger)
+    prefab_cloud_python.set_options(options)
+    while True:
+        time.sleep(1)
+        logger.warning(
+            f"value of `example-config` is {prefab_cloud_python.get_client().get('example-config', default='default value')}")
+        logger.error("ERROR message")
+        logger.warning("WARN message")
+        logger.info("INFO message")
+        logger.debug("DEBUG message")
+
+
+if __name__ == "__main__":
+    main()

--- a/mypy.ini
+++ b/mypy.ini
@@ -60,6 +60,7 @@ exclude = (?x)(
         | ^tests/test_telemetry_manager\.py$
         | ^tests/test_config_resolver\.py$
         | ^prefab_pb2.*\.pyi?$
+        | ^examples/
     )
 
 # Strict typing options


### PR DESCRIPTION
Adds a couple of examples based on code i've been using to test the client

* standard-logging: demonstrates configuring logging with the prefab filter
* gunicorn: demonstrates client working after process fork by resetting on the post_worker_init gunicorn hook

