### PR TITLE
Fix telemetry row index - the default(no-env) row isn't always index=1

### DIFF
--- a/prefab_cloud_python/config_resolver.py
+++ b/prefab_cloud_python/config_resolver.py
@@ -92,9 +92,9 @@ class CriteriaEvaluator:
         self.base_client = base_client
 
     def evaluate(self, props):
-        for value_index, conditional_value in enumerate(
-            self.matching_environment_row_values()
-        ):
+        matching_env_row_values = self.matching_environment_row_values()
+        default_row_index = 1 if matching_env_row_values else 0
+        for value_index, conditional_value in enumerate(matching_env_row_values):
             if self.all_criteria_match(conditional_value, props):
                 return Evaluation(
                     self.config,
@@ -110,7 +110,7 @@ class CriteriaEvaluator:
                     self.config,
                     conditional_value.value,
                     value_index,
-                    1,
+                    default_row_index,
                     props,
                     self.resolver,
                 )

--- a/tests/test_criteria_evaluator.py
+++ b/tests/test_criteria_evaluator.py
@@ -39,9 +39,31 @@ class TestCriteriaEvaluator:
         evaluator = CriteriaEvaluator(
             config, project_env_id, resolver=None, base_client=None
         )
-        assert (
-            evaluator.evaluate(context({})).raw_config_value().string == desired_value
+        evaluation = evaluator.evaluate(context({}))
+        assert evaluation.raw_config_value().string == desired_value
+        assert evaluation.config_row_index == 0
+
+    def test_no_env_row_index_is_zero_when_no_project_row_present(self):
+        config = Prefab.Config(
+            key=key,
+            rows=[
+                Prefab.ConfigRow(
+                    values=[
+                        Prefab.ConditionalValue(
+                            criteria=[Prefab.Criterion(operator="ALWAYS_TRUE")],
+                            value=Prefab.ConfigValue(string=desired_value),
+                        )
+                    ],
+                ),
+            ],
         )
+
+        evaluator = CriteriaEvaluator(
+            config, project_env_id, resolver=None, base_client=None
+        )
+        evaluation = evaluator.evaluate(context({}))
+        assert evaluation.raw_config_value().string == desired_value
+        assert evaluation.config_row_index == 0
 
     def test_nested_props_in(self):
         config = Prefab.Config(


### PR DESCRIPTION
It should be zero if there's no env-id matching row