### PR TITLE
Bump mmh3 version to 4.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [{include = "prefab_cloud_python"}, {include = "prefab_pb2.py"}]
 cryptography = ">= 42.0.0"
 python = ">= 3.9, < 4"
 pyyaml = "^6.0.0"
-mmh3 = "^3.0.0"
+mmh3 = "^4.1.0"
 requests = ">= 2.30.0"
 structlog = ">= 21.1.0"
 sseclient-py = "^1.7.2"


### PR DESCRIPTION
We're running into issues getting mmh3 to install in Python 3.12.1. Its trying to build from source which we dont really want. Bumping to 4.1.0 fixes this.