### PR TITLE
Improve reset shutdown case

### DIFF
--- a/prefab_cloud_python/__init__.py
+++ b/prefab_cloud_python/__init__.py
@@ -46,8 +46,9 @@ def get_client() -> Client:
 def reset_instance() -> None:
     """clears the singleton client instance so it will be recreated on the next get() call"""
     global __base_client
-    with __lock.write_locked():
-        old_client = __base_client
-        __base_client = None
-        if old_client:
-            old_client.close()
+    global __lock
+    __lock = _ReadWriteLock()
+    old_client = __base_client
+    __base_client = None
+    if old_client:
+        old_client.close()

--- a/prefab_cloud_python/config_client.py
+++ b/prefab_cloud_python/config_client.py
@@ -145,6 +145,9 @@ class ConfigClient:
                 self.sse_client = sseclient.SSEClient(response)
 
                 for event in self.sse_client.events():
+                    if self.base_client.shutdown_flag.is_set():
+                        logger.info("Client is shutting down, exiting SSE event loop")
+                        return
                     if event.data:
                         logger.info("Loading data from SSE stream")
                         configs = Prefab.Configs.FromString(
@@ -283,5 +286,4 @@ class ConfigClient:
         return self.is_initialized.is_set()
 
     def close(self) -> None:
-        if self.sse_client:
-            self.sse_client.close()
+        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prefab-cloud-python"
-version = "0.10.7"
+version = "0.10.8b1"
 description = "Python client for Prefab Feature Flags, Dynamic log levels, and Config as a Service: https://www.prefab.cloud"
 license = "MIT"
 authors = ["Michael Berkowitz <michael.berkowitz@gmail.com>", "James Kebinger <james.kebinger@prefab.cloud>"]


### PR DESCRIPTION
This change does two things to improve behavior on forking

1) the reset_instance command creates a new RWLock.
2) calling close on the old_client no longer calls close on the internal sse_client because that ultimately calls close on a response object with underlying network resource owned by the parent process and will hang