### PR TITLE
Add PyPI publish workflow with duplicate version check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,71 @@
+name: "Publish to PyPI"
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment: release
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: read
+
+    steps:
+      - name: Checkout repo + submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Check if version already published
+        id: version-check
+        run: |
+          VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "Current version: $VERSION"
+
+          # Check if this version exists on PyPI
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/prefab-cloud-python/$VERSION/json")
+
+          if [ "$HTTP_STATUS" = "200" ]; then
+            echo "Version $VERSION already exists on PyPI"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version $VERSION not found on PyPI, proceeding with publish"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install Poetry
+        if: steps.version-check.outputs.skip == 'false'
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+
+      - name: Install dependencies
+        if: steps.version-check.outputs.skip == 'false'
+        run: |
+          poetry install --no-interaction
+
+      - name: Run tests
+        if: steps.version-check.outputs.skip == 'false'
+        run: poetry run pytest -k 'not integration'
+        env:
+          PREFAB_INTEGRATION_TEST_API_KEY: ${{ secrets.PREFAB_INTEGRATION_TEST_API_KEY }}
+
+      - name: Build package
+        if: steps.version-check.outputs.skip == 'false'
+        run: poetry build
+
+      - name: Publish to PyPI
+        if: steps.version-check.outputs.skip == 'false'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/


### PR DESCRIPTION
## Summary

Backports the publish workflow from [ReforgeHQ/sdk-python](https://github.com/ReforgeHQ/sdk-python/blob/main/.github/workflows/publish.yml) and adapts it for prefab-cloud-python.

This adds automated publishing to PyPI when changes are pushed to main.

## Features

✅ **Smart version checking** - Queries PyPI API before publishing to prevent duplicate releases
✅ **Trusted publishing** - Uses OIDC authentication (no API tokens needed)
✅ **Test before publish** - Runs full test suite before building/publishing
✅ **Manual trigger** - Can be triggered via workflow_dispatch
✅ **Conditional execution** - Skips all steps if version already exists on PyPI

## Workflow Triggers

- **Automatic**: On push to `main` branch
- **Manual**: Via GitHub Actions UI (workflow_dispatch)

## How It Works

1. **Version Check**: Reads version from `pyproject.toml` and checks PyPI
2. **Skip if exists**: If version already on PyPI, skips all remaining steps
3. **Install & Test**: Sets up Poetry, installs dependencies, runs tests
4. **Build**: Creates distribution packages with `poetry build`
5. **Publish**: Uses PyPI's official action with trusted publishing

## Differences from sdk-python

Adapted for prefab-cloud-python:
- ✅ Reads version from `pyproject.toml` (instead of `VERSION` file)
- ✅ Uses `prefab-cloud-python` as PyPI package name
- ✅ Uses `PREFAB_INTEGRATION_TEST_API_KEY` secret (instead of REFORGE_*)
- ✅ Runs tests with `-k 'not integration'` filter (matches CI workflow)

## PyPI Configuration

Package: [`prefab-cloud-python`](https://pypi.org/project/prefab-cloud-python)

## Setup Required

Before this can work, you'll need to:

1. **Configure PyPI Trusted Publishing** (in PyPI account settings):
   - Publisher: GitHub
   - Owner: prefab-cloud
   - Repository: prefab-cloud-python
   - Workflow: publish.yml
   - Environment: release

2. **Create GitHub environment** named `release` (optional, for extra protection)

## Testing

To test without publishing:
- Bump version in `pyproject.toml` to a version that already exists on PyPI
- The workflow will detect it and skip publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)